### PR TITLE
Automated Changelog Entry for 0.1.1 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
-## 0.1.0
+## 0.1.1
+
+([Full Changelog](https://github.com/jupyter-server/jupyter_server_ydoc/compare/d175b8a607985886ef0fd51af994ae186b527c12...e91f593a4213e314508418e951dc3aa3bb66cdcf))
+
+### Bugs fixed
+
+- Remove docs link for now [#3](https://github.com/jupyter-server/jupyter_server_ydoc/pull/3) ([@davidbrochart](https://github.com/davidbrochart))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_server_ydoc/graphs/contributors?from=2022-07-10&to=2022-07-10&type=c))
+
+[@davidbrochart](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server_ydoc+involves%3Adavidbrochart+updated%3A2022-07-10..2022-07-10&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server_ydoc+involves%3Awelcome+updated%3A2022-07-10..2022-07-10&type=Issues)
 
 <!-- <END NEW CHANGELOG ENTRY> -->
+
+## 0.1.0


### PR DESCRIPTION
Automated Changelog Entry for 0.1.1 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyter-server/jupyter_server_ydoc  |
| Branch  | main  |
| Version Spec | next |
