### PR TITLE
Fix release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,8 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-  "jupyter_ydoc==0.1.23",
-  "ypy-websocket>=0.1.23"
+  "jupyter_ydoc==0.1.13",
+  "ypy-websocket>=0.1.13"
 ]
 
 [[project.authors]]


### PR DESCRIPTION
When publishing 0.1.2, the dependency versions were [automatically modified](https://github.com/jupyter-server/jupyter_server_ydoc/commit/37c1a6fb7e18834868e7b0f9c2fc58aea58557a0).