### PR TITLE
Adds a new setting for saving document delay

### DIFF
--- a/jupyter_server_ydoc/ydoc.py
+++ b/jupyter_server_ydoc/ydoc.py
@@ -260,7 +260,7 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
         seconds = self.settings["collaborative_document_save_delay"]
         if seconds is None:
             return
-        # save after X second of inactivity to prevent too frequent saving
+        # save after X seconds of inactivity
         await asyncio.sleep(seconds)
         # if the room cannot be found, don't save
         try:

--- a/jupyter_server_ydoc/ydoc.py
+++ b/jupyter_server_ydoc/ydoc.py
@@ -257,8 +257,11 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
         self.saving_document = asyncio.create_task(self.maybe_save_document())
 
     async def maybe_save_document(self):
-        # save after 1 second of inactivity to prevent too frequent saving
-        await asyncio.sleep(1)
+        seconds = self.settings["collaborative_document_save_delay"]
+        if seconds is None:
+            return
+        # save after X second of inactivity to prevent too frequent saving
+        await asyncio.sleep(seconds)
         # if the room cannot be found, don't save
         try:
             file_format, file_type, file_path = self.get_file_info()


### PR DESCRIPTION
I need to make the delay configurable because of JupyterLab UI Tests. When making a snapshot after opening/editing a notebook the icon for the dirty flag may or may not be there. We make sure the dirty icon is cleaned by setting the delay to 0 in the test.