### PR TITLE
Update ypy-websocket

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 requires-python = ">=3.7"
 dependencies = [
   "jupyter_ydoc>=0.2.0,<0.4.0",
-  "ypy-websocket>=0.5.0,<0.6.0",
+  "ypy-websocket>=0.6.0,<0.7.0",
   "jupyter_server_fileid >=0.6.0,<1"
 ]
 


### PR DESCRIPTION
Bump `ypy-websocket` dependency.

https://github.com/y-crdt/ypy-websocket/releases/tag/0.6.0