### PR TITLE
Pass logger to YStore

### DIFF
--- a/jupyter_server_ydoc/handlers.py
+++ b/jupyter_server_ydoc/handlers.py
@@ -92,7 +92,7 @@ class JupyterWebsocketServer(WebsocketServer):
                 p = Path(file_path)
                 updates_file_path = str(p.parent / f".{file_type}:{p.name}.y")
                 ystore = self.ystore_class(
-                    path=updates_file_path, metadata_callback=metadata_callback
+                    path=updates_file_path, metadata_callback=metadata_callback, log=self.log
                 )
                 self.rooms[path] = DocumentRoom(file_type, ystore, self.log)
             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 requires-python = ">=3.7"
 dependencies = [
   "jupyter_ydoc>=0.2.0,<0.4.0",
-  "ypy-websocket>=0.6.0,<0.7.0",
+  "ypy-websocket>=0.7.1,<0.8.0",
   "jupyter_server_fileid >=0.6.0,<1"
 ]
 


### PR DESCRIPTION
Needs https://github.com/y-crdt/ypy-websocket/pull/48 to be released.