### PR TITLE
Remove metadata

### DIFF
--- a/jupyter_server_ydoc/app.py
+++ b/jupyter_server_ydoc/app.py
@@ -46,7 +46,7 @@ class YDocExtension(ExtensionApp):
         config=True,
         help="""The YStore class to use for storing Y updates. Defaults to JupyterSQLiteYStore,
         which stores Y updates in a '.jupyter_ystore.db' SQLite database in the current
-        directory.""",
+        directory, and clears history every 24 hours.""",
     )
 
     def initialize_settings(self):

--- a/jupyter_server_ydoc/handlers.py
+++ b/jupyter_server_ydoc/handlers.py
@@ -30,6 +30,7 @@ class JupyterTempFileYStore(TempFileYStore):
 
 class JupyterSQLiteYStore(SQLiteYStore):
     db_path = ".jupyter_ystore.db"
+    document_ttl = 24 * 60 * 60
 
 
 class DocumentRoom(YRoom):

--- a/jupyter_server_ydoc/handlers.py
+++ b/jupyter_server_ydoc/handlers.py
@@ -3,7 +3,6 @@
 
 import asyncio
 import json
-from datetime import datetime
 from logging import Logger
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
@@ -55,13 +54,6 @@ class TransientRoom(YRoom):
         super().__init__(log=log)
 
 
-async def metadata_callback() -> bytes:
-    # the current datetime will be stored in metadata as bytes
-    # it can be retrieved as:
-    # datetime.fromisoformat(metadata.decode())
-    return datetime.utcnow().isoformat().encode()
-
-
 class JupyterWebsocketServer(WebsocketServer):
 
     rooms: Dict[str, YRoom]
@@ -91,9 +83,7 @@ class JupyterWebsocketServer(WebsocketServer):
                 file_format, file_type, file_path = path.split(":", 2)
                 p = Path(file_path)
                 updates_file_path = str(p.parent / f".{file_type}:{p.name}.y")
-                ystore = self.ystore_class(
-                    path=updates_file_path, metadata_callback=metadata_callback, log=self.log
-                )
+                ystore = self.ystore_class(path=updates_file_path, log=self.log)
                 self.rooms[path] = DocumentRoom(file_type, ystore, self.log)
             else:
                 # it is a transient document (e.g. awareness)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 requires-python = ">=3.7"
 dependencies = [
   "jupyter_ydoc>=0.2.0,<0.4.0",
-  "ypy-websocket>=0.7.1,<0.8.0",
+  "ypy-websocket>=0.8.0,<0.9.0",
   "jupyter_server_fileid >=0.6.0,<1"
 ]
 


### PR DESCRIPTION
The `SQLiteYStore` now has a built-in [timestamp](https://github.com/y-crdt/ypy-websocket/blob/3d55469a27f47168713c55f93e23bd0164a03bfa/ypy_websocket/ystore.py#L202), and I think we should have it built-in for `FileYstore` too.
The current metadata was also storing a timestamp, there is no need to store it twice.